### PR TITLE
Omit Exterior lights from modification

### DIFF
--- a/ImproveInteriorLighting.cs
+++ b/ImproveInteriorLighting.cs
@@ -72,7 +72,7 @@ namespace ImprovedInteriorLighting
             {
                 //We don't want to adjust the torch when we enter the interior
                 // if (dfLight.gameObject.name != "Torch" && (handPaintedModFound == false || handPaintedModFound == true && dfLight.transform.parent.name.Contains("[Replacement]"))) {
-                if (dfLight.gameObject.name != "Torch")
+                if (dfLight.gameObject.name != "Torch" && dfLight.transform.root.name != "Exterior")
                 {
                     dfLight.intensity = interiorModSettings.InteriorLightsIntensity;
                     dfLight.shadows = LightShadows.Soft;


### PR DESCRIPTION
This is a fix to make my Transparent Windows mod compatible with your mod. Before my mod you would not need to be concerned with exterior light sources, but my mod re-enables them so you can see out of the window.

This simple one line change will mean exterior lights won't get updated.